### PR TITLE
Unsubscribe to single listenters.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # covjs
 
-A super lightweight pubsub module. < 1Kb minified. 
+A super lightweight pubsub module. Around 1Kb minified.
 
 _Cov is short for covenants._
 
@@ -32,8 +32,33 @@ cov.on('Cov-Name', function(arg1, arg2) {
 cov.signal('Cov-Name', ['argument 1', 'argument 2']);
 ```
 
-### Unsubscribe from a Covenant
+### Unsubscribe all from a Covenant
+
+#### To unsubscribe all listeners from a Covenant:
 ```javascript
 // unsubscribe from 'Cov-Name'
 cov.off('Cov-Name');
+```
+
+#### To unsubscribe one specific listener from a Covenant:
+
+You'll need to save the token returned by your call to `cov.on()`
+
+```javascript
+var firstListener = cov.on('foo', function() {
+	console.log('First Listener has fired!');
+});
+
+var secondListener = cov.on('foo', function() {
+	console.log('Second listener has fired!');
+});
+
+// Both First and Second Listeners will fire
+cov.signal('foo');
+
+// Unsubscribe just the first Listener
+cov.off('foo', firstListener);
+
+// Only Second Listener will fire
+cov.signal('foo');
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # covjs
 
-A super lightweight pubsub module. Around 1Kb minified.
+A super lightweight pubsub module. Around 1Kb minified, _under 500B minified and gzipped_.
 
 _Cov is short for covenants._
 
@@ -26,6 +26,20 @@ cov.on('Cov-Name', function(arg1, arg2) {
 });
 ```
 
+#### Subscribe to a covenant only once
+
+```javascript
+// Function will only fire for first signal of 'Cov-Name'.
+cov.once('Cov-Name', function(arg1, arg2) {
+    var data = {
+        foo: arg1,
+        bar: arg2
+    };
+
+    doSomethingOnce(data)
+});
+```
+
 ### Signal a covenant (publish)
 ```javascript
 // Signal this covenant with 2 arguments
@@ -45,20 +59,20 @@ cov.off('Cov-Name');
 You'll need to save the token returned by your call to `cov.on()`
 
 ```javascript
-var firstListener = cov.on('foo', function() {
+var firstListener = cov.on('Cov-Name', function() {
 	console.log('First Listener has fired!');
 });
 
-var secondListener = cov.on('foo', function() {
+var secondListener = cov.on('Cov-Name', function() {
 	console.log('Second listener has fired!');
 });
 
 // Both First and Second Listeners will fire
-cov.signal('foo');
+cov.signal('Cov-Name');
 
 // Unsubscribe just the first Listener
-cov.off('foo', firstListener);
+cov.off('Cov-Name', firstListener);
 
 // Only Second Listener will fire
-cov.signal('foo');
+cov.signal('Cov-Name');
 ```

--- a/cov.js
+++ b/cov.js
@@ -85,10 +85,10 @@ var Cov = {
 		var name = arguments.length <= 0 || arguments[0] === undefined ? false : arguments[0];
 		var fn = arguments.length <= 1 || arguments[1] === undefined ? false : arguments[1];
 
-		var newId = callbackId + 1;
+		var newId = 'cov_' + (callbackId + 1);
 		var oneTimeFunc = function() {
 			fn.apply(null, arguments);
-			this.off(name, 'cov_' + newId);
+			this.off(name, newId);
 		}.bind(this);
 
 		this.on(name, oneTimeFunc);

--- a/cov.js
+++ b/cov.js
@@ -76,6 +76,28 @@ var Cov = {
 
 
 	/**
+	 * Register an event to fire only once
+	 * @param   {String}  name    Name of the event like: 'loaded'
+	 * @param   {Function}  fn    The closure to execute when signaled.
+	 * @return  {Mixed}           Unique ID for listener or false on incorrect parameters
+	 */
+	once: function once() {
+		var name = arguments.length <= 0 || arguments[0] === undefined ? false : arguments[0];
+		var fn = arguments.length <= 1 || arguments[1] === undefined ? false : arguments[1];
+
+		var newId = callbackId + 1;
+		var oneTimeFunc = function() {
+			fn.apply(null, arguments);
+			this.off(name, 'cov_' + newId);
+		}.bind(this);
+
+		this.on(name, oneTimeFunc);
+
+		return newId;
+	},
+
+
+	/**
 	 * Signal an event and run all of its subscribed functions.
 	 * @param  {String}    name  Name of the event like: 'loaded';
 	 * @param  {object[]}  args  Any arguments that need to be sent to the  fn

--- a/cov.js
+++ b/cov.js
@@ -13,22 +13,22 @@ function _isFn(fn) {
 }
 
 /**
+ * Store incrementing ID for each passed callback
+ * @type  {Int}
+ */
+var callbackId = 0;
+
+/**
+ * Store all of our covenants
+ * @type  {Array}
+ */
+var covenants = [];
+
+/**
  * One object to hold all of the apps covenants.
  * @type {Object}
  */
 var Cov = {
-
-	/**
-	 * Store incrementing ID for each passed callback
-	 * @type  {Int}
-	 */
-	callbackId: 0,
-
-	/**
-	 * Store all of our covenants
-	 * @type  {Array}
-	 */
-	covenants: [],
 
 	/**
 	 * Register an event, or add to an existing event
@@ -46,12 +46,12 @@ var Cov = {
 		if (name && fn && isFn) {
 			var _exists = false;
 			var cbObj = {
-				id: 'cov_' + (++this.callbackId),
+				id: 'cov_' + (++callbackId),
 				fn: fn
 			}
 
 			// check if this even exists
-			this.covenants.forEach(function (cov) {
+			covenants.forEach(function (cov) {
 				// If it already exists, add the function to its functions.
 				if (cov.name === name) {
 					cov.callbacks.push(cbObj);
@@ -67,7 +67,7 @@ var Cov = {
 					callbacks: [cbObj]
 				};
 
-				this.covenants.push(newCovenant);
+				covenants.push(newCovenant);
 			}
 			return cbObj.id;
 		}
@@ -77,8 +77,9 @@ var Cov = {
 
 	/**
 	 * Signal an event and run all of its subscribed functions.
-	 * @param {String}    name  Name of the event like: 'loaded';
-	 * @param {object[]}  args  Any arguments that need to be sent to the  fn
+	 * @param  {String}    name  Name of the event like: 'loaded';
+	 * @param  {object[]}  args  Any arguments that need to be sent to the  fn
+	 * @return {object}          Current instance of Cov, to allow for chaining
 	 */
 	signal: function signal() {
 		var name = arguments.length <= 0 || arguments[0] === undefined ? false : arguments[0];
@@ -86,7 +87,7 @@ var Cov = {
 
 
 		if (name) {
-			this.covenants.forEach(function (cov) {
+			covenants.forEach(function (cov) {
 				if (cov.name === name) {
 
 					cov.callbacks.forEach(function (cbObj) {
@@ -97,6 +98,8 @@ var Cov = {
 				}
 			});
 		}
+
+		return this;
 	},
 
 
@@ -104,13 +107,14 @@ var Cov = {
 	 * Unregister (turn off) an event.
 	 * @param  {String}  Name of the event like: 'loaded';
 	 * @param  {String}  ID of listener as returned by `on` function
+	 * @return {object}  Current instance of Cov, to allow for chaining
 	 */
 	off: function off() {
 		var name = arguments.length <= 0 || arguments[0] === undefined ? false : arguments[0];
 		var id = arguments.length <= 1 || arguments[1] === undefined ? false : arguments[1];
 
 		if (name) {
-			this.covenants.forEach(function (cov, index, arr) {
+			covenants.forEach(function (cov, index, arr) {
 				if (cov.name === name) {
 					// If no ID is passed, remove all listeners
 					if (!id) {
@@ -127,8 +131,9 @@ var Cov = {
 				}
 			});
 		}
-	},
 
+		return this;
+	}
 };
 
 module.exports = Cov;

--- a/cov.js
+++ b/cov.js
@@ -19,6 +19,12 @@ function _isFn(fn) {
 var Cov = {
 
 	/**
+	 * Store incrementing ID for each passed callback
+	 * @type  {Int}
+	 */
+	callbackId: 0,
+
+	/**
 	 * Store all of our covenants
 	 * @type  {Array}
 	 */
@@ -28,6 +34,7 @@ var Cov = {
 	 * Register an event, or add to an existing event
 	 * @param   {String}  name    Name of the event like: 'loaded'
 	 * @param   {Function}  fn    The closure to execute when signaled.
+	 * @return  {Mixed}           Unique ID for listener or false on incorrect parameters
 	 */
 	on: function on() {
 		var name = arguments.length <= 0 || arguments[0] === undefined ? false : arguments[0];
@@ -38,12 +45,16 @@ var Cov = {
 
 		if (name && fn && isFn) {
 			var _exists = false;
+			var cbObj = {
+				id: 'cov_' + (++this.callbackId),
+				fn: fn
+			}
 
 			// check if this even exists
 			this.covenants.forEach(function (cov) {
 				// If it already exists, add the function to its functions.
 				if (cov.name === name) {
-					cov.callbacks.push(fn);
+					cov.callbacks.push(cbObj);
 					_exists = true;
 					return;
 				}
@@ -53,12 +64,14 @@ var Cov = {
 			if (!_exists) {
 				var newCovenant = {
 					name: name,
-					callbacks: [fn]
+					callbacks: [cbObj]
 				};
 
 				this.covenants.push(newCovenant);
 			}
+			return cbObj.id;
 		}
+		return false;
 	},
 
 
@@ -76,8 +89,8 @@ var Cov = {
 			this.covenants.forEach(function (cov) {
 				if (cov.name === name) {
 
-					cov.callbacks.forEach(function (fn) {
-						fn.apply(null, args);
+					cov.callbacks.forEach(function (cbObj) {
+						cbObj.fn.apply(null, args);
 					});
 
 					return;
@@ -90,16 +103,26 @@ var Cov = {
 	/**
 	 * Unregister (turn off) an event.
 	 * @param  {String}  Name of the event like: 'loaded';
+	 * @param  {String}  ID of listener as returned by `on` function
 	 */
 	off: function off() {
 		var name = arguments.length <= 0 || arguments[0] === undefined ? false : arguments[0];
+		var id = arguments.length <= 1 || arguments[1] === undefined ? false : arguments[1];
 
 		if (name) {
-			this.covenants.forEach(function (ev, index, arr) {
-				if (ev.name === name) {
-
-					arr.splice(index, 1);
-
+			this.covenants.forEach(function (cov, index, arr) {
+				if (cov.name === name) {
+					// If no ID is passed, remove all listeners
+					if (!id) {
+						arr.splice(index, 1);
+					} else {
+					// Otherwise just remove specified callback
+						cov.callbacks.forEach(function(cbObj, ix, callbacks) {
+							if (cbObj.id === id) {
+								callbacks.splice(ix, 1);
+							}
+						});
+					}
 					return;
 				}
 			});


### PR DESCRIPTION
1. Added ability to `off` a single listener:
```
var token = cov.on('foo', function() { console.log('Foo Happened'); });
cov.off('foo', token);
// Other listeners to foo will continue to work
```

2. Added `once` method:
```
cov.once('foo', function() { console.log('I will only ever get called once'); });
```

3. Added ability to chain `signal` and `off` methods
```
cov.off('myevent').on('myevent', function(){ console.log('You can run this line as many times as you want.') });
```
